### PR TITLE
fix: update mariadb import for ESM connector compatibility

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2,7 +2,7 @@
  * MariaDB connection management for MCP server
  */
 
-import mariadb from "mariadb";
+import * as mariadb from "mariadb";
 import { MariaDBConfig } from "./types.js";
 import { isAlloowedQuery } from "./validators.js";
 

--- a/test-setup.js
+++ b/test-setup.js
@@ -21,7 +21,7 @@
  *   MARIADB_ALLOW_DELETE - false
  */
 
-import mariadb from 'mariadb';
+import * as mariadb from 'mariadb';
 import * as dotenv from 'dotenv';
 
 // Load environment variables from .env file


### PR DESCRIPTION
### Summary
- Fix runtime error with recent `mariadb` releases that migrated from CommonJS to ESM (CONJS-326)
- Replace default import with namespace import in `src/connection.ts`
- Keep source aligned with compiled output behavior and avoid future build regressions

### Problem
Recent `mariadb` versions no longer expose a default export, causing:
`SyntaxError: The requested module 'mariadb' does not provide an export named 'default'`

 ### Fix
Use:
`import * as mariadb from "mariadb";`
This matches the package’s ESM export shape and restores compatibility.